### PR TITLE
Queueing and message management

### DIFF
--- a/source/renaissance/server/messagemanager.d
+++ b/source/renaissance/server/messagemanager.d
@@ -188,20 +188,6 @@ public class Queue : QueueIntrospective
         this.policy = policy;
     }
 
-    public static Queue makeSmart(size_t maxSize)
-    {
-        SmartPolicy smartPolicy = SmartPolicy(maxSize);
-        PolicyFunction smartPolicyFunction = &smartPolicy.enact;
-
-        Queue smartQueue = new Queue(smartPolicyFunction);
-        return smartQueue;
-    }
-
-    public static makeSmart()
-    {
-        return makeSmart(QUEUE_DEFAULT_SIZE);
-    }
-
     public void enqueue(Message message)
     {
         // Lock the queue

--- a/source/renaissance/server/messagemanager.d
+++ b/source/renaissance/server/messagemanager.d
@@ -104,6 +104,15 @@ public struct SmartPolicy
     {
         // TODO: Implement me
 
+        // Lock the queue
+        queue.lockQueue();
+
+        // Obtain the queue
+        // TODO: Implement me
+
+        // Unlock the queue
+        queue.unlockQueue();
+
 
         return PolicyDecision.ACCEPT;
     }
@@ -117,9 +126,9 @@ public struct SmartPolicy
  */
 public interface QueueIntrospective
 {
-    private void lockQueue();
-    private DList!(Message) getQueue();
-    private void unlockQueue();
+    protected void lockQueue();
+    protected DList!(Message) getQueue();
+    protected void unlockQueue();
 }
 
 public enum QUEUE_DEFAULT_SIZE = 100;
@@ -190,19 +199,19 @@ public class Queue : QueueIntrospective
         this.queue.insertAfter(this.queue[], message);
     }
 
-    private void lockQueue()
+    protected void lockQueue()
     {
         // Lock the queue
         this.lock.lock();
     }
 
-    private void unlockQueue()
+    protected void unlockQueue()
     {
         // Unlock the queue
         return this.lock.unlock();
     }
 
-    private DList!(Message) getQueue()
+    protected DList!(Message) getQueue()
     {
         return this.queue;
     }

--- a/source/renaissance/server/messagemanager.d
+++ b/source/renaissance/server/messagemanager.d
@@ -136,7 +136,16 @@ public enum PolicyDecision
      * should be appended
      * to the queue
      */
-    ACCEPT
+    ACCEPT,
+
+    /** 
+     * The incoming item
+     * should be appended
+     * to the queue but
+     * no hooks should
+     * be run
+     */
+    ACCEPT_SILENT
 }
 
 /** 

--- a/source/renaissance/server/messagemanager.d
+++ b/source/renaissance/server/messagemanager.d
@@ -51,16 +51,30 @@ public enum PolicyDecision
  */
 public alias PolicyFunction = PolicyDecision function(Message, Queue);
 
+/** 
+ * NOP policy does nothing and always
+ * returns a positive (`ACCEPT`'d)
+ * verdict
+ *
+ * Returns: `PolicyDecision.ACCEPT` always
+ */
+public PolicyDecision nop(Message, Queue)
+{
+    return PolicyDecision.ACCEPT;
+}
+
 // TODO: Templatize in the future on the T element type
 public class Queue
 {
     private size_t maxSize;
+    private PolicyFunction policy;
     private DList!(Message) queue;
     private Mutex lock;
 
-    public this(size_t maxSize = QUEUE_DEFAULT_SIZE)
+    public this(size_t maxSize = QUEUE_DEFAULT_SIZE, PolicyFunction policy = &nop)
     {
         this.lock = new Mutex();
+        this.policy = policy;
     }
 
     public void enqueue(Message message)

--- a/source/renaissance/server/messagemanager.d
+++ b/source/renaissance/server/messagemanager.d
@@ -269,6 +269,53 @@ public class Queue : QueueIntrospective
     }
 }
 
+unittest
+{
+    bool touch = false;
+    void dummyHook(Message, Queue)
+    {
+        touch = true;
+    }
+
+    PolicyDecision dummyPolicy(Message, Queue)
+    {
+        return PolicyDecision.ACCEPT;
+    }
+
+    Queue queue = new Queue(cast(PolicyFunction)&dummyPolicy);
+    queue.setEnqueueHook(&dummyHook);
+
+    // Enqueue something
+    queue.enqueue(Message());
+
+    // It should have triggered the hook
+    assert(touch);
+}
+
+unittest
+{
+    bool touch = false;
+    void dummyHook(Message, Queue)
+    {
+        touch = true;
+    }
+
+    PolicyDecision dummyPolicy(Message, Queue)
+    {
+        return PolicyDecision.DROP_INCOMING;
+    }
+
+    Queue queue = new Queue(cast(PolicyFunction)&dummyPolicy);
+    queue.setEnqueueHook(&dummyHook);
+
+    // Enqueue something
+    queue.enqueue(Message());
+
+    // It must have been dropped, therefore the
+    // ... hook should have never ran
+    assert(touch == false);
+}
+
 
 public interface MessageDeliveryTransport
 {
@@ -339,51 +386,4 @@ public class MessageManager
 
         return manager;
     }
-}
-
-unittest
-{
-    bool touch = false;
-    void dummyHook(Message, Queue)
-    {
-        touch = true;
-    }
-
-    PolicyDecision dummyPolicy(Message, Queue)
-    {
-        return PolicyDecision.ACCEPT;
-    }
-
-    Queue queue = new Queue(cast(PolicyFunction)&dummyPolicy);
-    queue.setEnqueueHook(&dummyHook);
-
-    // Enqueue something
-    queue.enqueue(Message());
-
-    // It should have triggered the hook
-    assert(touch);
-}
-
-unittest
-{
-    bool touch = false;
-    void dummyHook(Message, Queue)
-    {
-        touch = true;
-    }
-
-    PolicyDecision dummyPolicy(Message, Queue)
-    {
-        return PolicyDecision.DROP_INCOMING;
-    }
-
-    Queue queue = new Queue(cast(PolicyFunction)&dummyPolicy);
-    queue.setEnqueueHook(&dummyHook);
-
-    // Enqueue something
-    queue.enqueue(Message());
-
-    // It must have been dropped, therefore the
-    // ... hook should have never ran
-    assert(touch == false);
 }

--- a/source/renaissance/server/messagemanager.d
+++ b/source/renaissance/server/messagemanager.d
@@ -90,7 +90,7 @@ public class Queue
         }
 
         // Apply queuing policy
-        PolicyDecision decision = policyCheck();
+        PolicyDecision decision = policy(message, this);
         logger.dbg("Queue decision: ", decision);
 
         // If we should tail-drop
@@ -113,12 +113,6 @@ public class Queue
     
         // Enqueue
         this.queue.insertAfter(this.queue[], message);
-    }
-
-    private PolicyDecision policyCheck() // NOTE: In future must use lock if decision requires anlysing internal queue
-    {
-        // TODO: Implement me
-        return PolicyDecision.ACCEPT;
     }
 }
 

--- a/source/renaissance/server/messagemanager.d
+++ b/source/renaissance/server/messagemanager.d
@@ -296,15 +296,10 @@ public class MessageManager
     private this()
     {
         // Initialize the queues (send+receive)
-        // this.sendQueue = new Queue();
-        // this.receiveQueue = new Queue();
-
         this.smrtPol = SmartPolicy(QUEUE_DEFAULT_SIZE);
         this.sendQueue = new Queue(&smrtPol.enact);
-        // this.sendQueue.setEnqueueHook(toDelegate(&dummyHook));
         this.sendQueue.setEnqueueHook(&this.stubDeliverSend);
         this.receiveQueue = new Queue(&smrtPol.enact);
-        // this.receiveQueue.setEnqueueHook(toDelegate(&dummyHook));
         this.receiveQueue.setEnqueueHook(&this.stubDeliverRecv);
     }
 

--- a/source/renaissance/server/messagemanager.d
+++ b/source/renaissance/server/messagemanager.d
@@ -340,3 +340,26 @@ public class MessageManager
         return manager;
     }
 }
+
+unittest
+{
+    bool touch = false;
+    void dummyHook(Message, Queue)
+    {
+        touch = true;
+    }
+
+    PolicyDecision dummyPolicy(Message, Queue)
+    {
+        return PolicyDecision.ACCEPT;
+    }
+
+    Queue queue = new Queue(cast(PolicyFunction)&dummyPolicy);
+    queue.setEnqueueHook(&dummyHook);
+
+    // Enqueue something
+    queue.enqueue(Message());
+
+    // It should have triggered the hook
+    assert(touch);
+}

--- a/source/renaissance/server/messagemanager.d
+++ b/source/renaissance/server/messagemanager.d
@@ -304,13 +304,20 @@ public class Queue : QueueIntrospective
         {
             // Fall through
         }
+        // Accept (silent)
+        else if(decision == PolicyDecision.ACCEPT_SILENT)
+        {
+            // Fall through
+        }
     
         // Enqueue
         this.queue.insertAfter(this.queue[], message);
 
         // Run enqueue hook (If enqueue hook starts a thread which tries lcking queue to do something
-        // .. and then awiats (in its delegate) on that it will obviousl deadlock)
-        if(this.enqueueHook)
+        // .. and then awiats (in its delegate) on that it will obviously deadlock)
+        //
+        // Only run if a hook exists AND if not silent
+        if(this.enqueueHook && decision != PolicyDecision.ACCEPT_SILENT)
         {
             this.enqueueHook(message, this);
         }

--- a/source/renaissance/server/messagemanager.d
+++ b/source/renaissance/server/messagemanager.d
@@ -309,9 +309,6 @@ public class MessageManager
 
         // Enqueue to send-q
         this.sendQueue.enqueue(message);
-
-        // Deliver
-        stubDeliverSend(message, this.sendQueue);
     }
 
     public void recvq(Message message)
@@ -320,9 +317,6 @@ public class MessageManager
 
         // Enqueue to recv-q
         this.receiveQueue.enqueue(message);
-
-        // Deliver
-        stubDeliverRecv(message, this.receiveQueue);
     }
 
     // NOTE: Stub delivery method - not smart in anyway

--- a/source/renaissance/server/messagemanager.d
+++ b/source/renaissance/server/messagemanager.d
@@ -319,13 +319,13 @@ public class MessageManager
         this.receiveQueue.enqueue(message);
     }
 
-    // NOTE: Stub delivery method - not smart in anyway
+    // NOTE: Stub delivery method to match EnqueueHook API
     private void stubDeliverSend(Message latest, Queue from)
     {
         transport.onOutgoing(latest, from);
     }
 
-    // NOTE: Stub delivery method - not smart in anyway
+    // NOTE: Stub delivery method to match EnqueueHook API
     private void stubDeliverRecv(Message latest, Queue from)
     {
         transport.onIncoming(latest, from);

--- a/source/renaissance/server/messagemanager.d
+++ b/source/renaissance/server/messagemanager.d
@@ -43,6 +43,14 @@ public enum PolicyDecision
     ACCEPT
 }
 
+/** 
+ * Describes a function which can be used
+ * for examining the latest item incoming
+ * the queue, along with the queue itself
+ * and return a verdict based on it
+ */
+public alias PolicyFunction = PolicyDecision function(Message, Queue);
+
 // TODO: Templatize in the future on the T element type
 public class Queue
 {

--- a/source/renaissance/server/messagemanager.d
+++ b/source/renaissance/server/messagemanager.d
@@ -134,6 +134,9 @@ public class MessageManager
 
         // Enqueue to send-q
         this.sendQueue.enqueue(message);
+
+        // Deliver
+        stubDeliverSend(message, this.sendQueue);
     }
 
     public void recvq(Message message)
@@ -142,6 +145,21 @@ public class MessageManager
 
         // Enqueue to recv-q
         this.receiveQueue.enqueue(message);
+
+        // Deliver
+        stubDeliverRecv(message, this.receiveQueue);
+    }
+
+    // NOTE: Stub delivery method - not smart in anyway
+    private void stubDeliverSend(Message latest, Queue from)
+    {
+        transport.onOutgoing(latest, from);
+    }
+
+    // NOTE: Stub delivery method - not smart in anyway
+    private void stubDeliverRecv(Message latest, Queue from)
+    {
+        transport.onIncoming(latest, from);
     }
     
     public static MessageManager create(MessageDeliveryTransport transport)

--- a/source/renaissance/server/messagemanager.d
+++ b/source/renaissance/server/messagemanager.d
@@ -63,6 +63,18 @@ public PolicyDecision nop(Message, Queue)
     return PolicyDecision.ACCEPT;
 }
 
+/** 
+ * Defines the interface which policy
+ * functions can use in order to access
+ * the internals of a given queue
+ */
+public interface QueueIntrospective
+{
+    private void lockQueue();
+    private DList!(Message) getQueue();
+    private void unlockQueue();
+}
+
 // TODO: Templatize in the future on the T element type
 public class Queue
 {

--- a/source/renaissance/server/messagemanager.d
+++ b/source/renaissance/server/messagemanager.d
@@ -232,8 +232,10 @@ public class MessageManager
     private this()
     {
         // Initialize the queues (send+receive)
-        this.sendQueue = new Queue();
-        this.receiveQueue = new Queue();
+        // this.sendQueue = new Queue();
+        // this.receiveQueue = new Queue();
+        this.sendQueue = Queue.makeSmart();
+        this.receiveQueue = Queue.makeSmart();
     }
 
     public void sendq(Message message)

--- a/source/renaissance/server/messagemanager.d
+++ b/source/renaissance/server/messagemanager.d
@@ -36,10 +36,37 @@ public struct Message
 
 public enum QUEUE_DEFAULT_SIZE = 100;
 
+/** 
+ * The verdict of any `PolicyFunction`
+ *
+ * This drives the decisions made
+ * within the `Queue` in terms of
+ * how it shoukd behave
+ */
 public enum PolicyDecision
 {
+    /**
+     * Don't modify the queue
+     * at all. Essentially
+     * dropping the incoming
+     * item
+     */
     DROP_INCOMING,
+
+    /**
+     * The item at the tail
+     * of the queue should be
+     * dropped so as to make
+     * space for a new item
+     * in its place
+     */
     DROP_TAIL,
+    
+    /** 
+     * The incoming item
+     * should be appended
+     * to the queue
+     */
     ACCEPT
 }
 

--- a/source/renaissance/server/messagemanager.d
+++ b/source/renaissance/server/messagemanager.d
@@ -387,3 +387,39 @@ public class MessageManager
         return manager;
     }
 }
+
+unittest
+{
+    Message r1;
+    Message r2;
+
+    // Create a dummy delivery transport
+    MessageDeliveryTransport dummy = new class MessageDeliveryTransport
+    {
+        public bool onOutgoing(Message latest, Queue from)
+        {
+            r1 = latest;
+            return true;
+        }
+        
+        public bool onIncoming(Message latest, Queue from)
+        {
+            r2 = latest;
+            return true;
+        }
+    };
+
+    // Create a message manager
+    MessageManager mesgMan = MessageManager.create(dummy);
+
+    // Enqueue messages to the send and receive queues
+    Message m1 = Message("deavmi", "gustav", "Hi Tristan, how you're doing?");
+    mesgMan.sendq(m1);
+
+    Message m2 = Message("gustav", "deavmi", "Doing well thanks!");
+    mesgMan.recvq(m2);
+
+    // Check that the delivery transport handled these
+    assert(r1 == m1);
+    assert(r2 == m2);
+}

--- a/source/renaissance/server/messagemanager.d
+++ b/source/renaissance/server/messagemanager.d
@@ -49,7 +49,7 @@ public enum PolicyDecision
  * the queue, along with the queue itself
  * and return a verdict based on it
  */
-public alias PolicyFunction = PolicyDecision function(Message, Queue);
+public alias PolicyFunction = PolicyDecision function(Message, QueueIntrospective);
 
 /** 
  * NOP policy does nothing and always
@@ -58,7 +58,7 @@ public alias PolicyFunction = PolicyDecision function(Message, Queue);
  *
  * Returns: `PolicyDecision.ACCEPT` always
  */
-public PolicyDecision nop(Message, Queue)
+public PolicyDecision nop(Message, QueueIntrospective)
 {
     return PolicyDecision.ACCEPT;
 }
@@ -76,9 +76,9 @@ public interface QueueIntrospective
 }
 
 // TODO: Templatize in the future on the T element type
-public class Queue
+public class Queue : QueueIntrospective
 {
-    private size_t maxSize;
+    private size_t maxSize; // TODO: Remove this and make a policy which respects it
     private PolicyFunction policy;
     private DList!(Message) queue;
     private Mutex lock;
@@ -125,6 +125,23 @@ public class Queue
     
         // Enqueue
         this.queue.insertAfter(this.queue[], message);
+    }
+
+    private void lockQueue()
+    {
+        // Lock the queue
+        this.lock.lock();
+    }
+
+    private void unlockQueue()
+    {
+        // Unlock the queue
+        return this.lock.unlock();
+    }
+
+    private DList!(Message) getQueue()
+    {
+        return this.queue;
     }
 }
 

--- a/source/renaissance/server/messagemanager.d
+++ b/source/renaissance/server/messagemanager.d
@@ -169,10 +169,13 @@ public interface QueueIntrospective
 {
     protected void lockQueue();
     protected ref DList!(Message) getQueue();  // NOTE: TO not copy the struct, also could allow replacing whole item (NOT GOOD)
+                                                // NOTE: We should not, because honetslu we have a lock so nothing CAN change
+                                                // AND we should NEVER change anyuthing in the queue
+                                                // TODO (Rather): expose a set of common things
     protected void unlockQueue();
 }
 
-public enum QUEUE_DEFAULT_SIZE = 0;
+public enum QUEUE_DEFAULT_SIZE = 100;
 
 // TODO: Templatize in the future on the T element type
 public class Queue : QueueIntrospective

--- a/source/renaissance/server/messagemanager.d
+++ b/source/renaissance/server/messagemanager.d
@@ -34,8 +34,6 @@ public struct Message
     }
 }
 
-public enum QUEUE_DEFAULT_SIZE = 100;
-
 /** 
  * The verdict of any `PolicyFunction`
  *
@@ -101,6 +99,8 @@ public interface QueueIntrospective
     private DList!(Message) getQueue();
     private void unlockQueue();
 }
+
+public enum QUEUE_DEFAULT_SIZE = 100;
 
 // TODO: Templatize in the future on the T element type
 public class Queue : QueueIntrospective

--- a/source/renaissance/server/messagemanager.d
+++ b/source/renaissance/server/messagemanager.d
@@ -363,3 +363,27 @@ unittest
     // It should have triggered the hook
     assert(touch);
 }
+
+unittest
+{
+    bool touch = false;
+    void dummyHook(Message, Queue)
+    {
+        touch = true;
+    }
+
+    PolicyDecision dummyPolicy(Message, Queue)
+    {
+        return PolicyDecision.DROP_INCOMING;
+    }
+
+    Queue queue = new Queue(cast(PolicyFunction)&dummyPolicy);
+    queue.setEnqueueHook(&dummyHook);
+
+    // Enqueue something
+    queue.enqueue(Message());
+
+    // It must have been dropped, therefore the
+    // ... hook should have never ran
+    assert(touch == false);
+}


### PR DESCRIPTION
## Purpose :writing_hand: 

The purpose of this PR is to focus solely on the following components:

1. `Queue`
2. `MessageManager`
3. `MessageDeliveryTransport`

The end goal is to have a re-usable `Queue` type which supports different sorts of policies (independent of our specific use case) and which can have hooks that are to be called dependent on these different types of policies.

We then want to be able to have the `MessageManager` provide custom hooks to these queues, which inevitably will make their way to the provided `MessageDeliveryTransport` then.

## Todo :white_check_mark: 

- [ ] Queue
    - [x] Define custom policies
        - [x] Verdict types: `ACCEPT`, `DROP_TAIL`, `DROP_INCOMING`
        - [x] `PolicyFunction` for determining outcome/verdict
            - [x] Stateless version
            - [x] Stateful version
            - [x] Requires a delegate perhaps for outside state?
    - [x] Define a hooking mechanism
    - [ ] Templatize to any types
        - [ ] Queue
        - [ ] Hooks
        - [ ] Policies

- [ ] Documentation
    - [ ] Internals + API docs
    - [x] Message
    - [ ] Queue
    - [ ] MessageManager
    - [x] MessageDeliveryTransport

- [ ] Unit tests
    - [x] Queue
    - [x] Message manager