### PR TITLE
StreamListener accept() handling

### DIFF
--- a/source/renaissance/listeners/listener.d
+++ b/source/renaissance/listeners/listener.d
@@ -38,4 +38,8 @@ public abstract class Listener
     public abstract void startListener();
 
     public abstract void stopListener();
+
+    // TODO: Nudge method to wake up a listener
+    // ... from something - implementation specific
+    public abstract void nudge();
 }

--- a/source/renaissance/listeners/stream.d
+++ b/source/renaissance/listeners/stream.d
@@ -9,6 +9,8 @@ import river.impls.sock : SockStream;
 import core.thread;
 import renaissance.connection;
 import renaissance.logging;
+import core.sync.mutex : Mutex;
+import core.sync.condition : Condition;
 
 public class StreamListener : Listener
 {
@@ -29,6 +31,9 @@ public class StreamListener : Listener
      */
     private Thread workerThread;
 
+    private Mutex backoffMutex;
+    private Condition backoffCond;
+
     /** 
      * Whether or not we are running
      *
@@ -48,9 +53,13 @@ public class StreamListener : Listener
 
         /* When started, the thread should run the connectionLoop() */
         workerThread = new Thread(&connectionLoop);
+
+        /* Initialize the backoff facilities */
+        this.backoffMutex = new Mutex();
+        this.backoffCond = new Condition(this.backoffMutex);
     }
 
-    Duration backoff = dur!("seconds")(1);
+    Duration backoffDuration = dur!("seconds")(1);
 
     private void connectionLoop()
     {
@@ -70,8 +79,8 @@ public class StreamListener : Listener
                 // TODO: Handling accept (which creates a new socket pair) is a problem
                 // ... we must code a backoff in hopes some client disconnects freeing
                 // ... up space for a new fd pair to be created
-                logger.warn("Waiting ", this.backoff, " many seconds before retrying...");
-                Thread.sleep(this.backoff);
+                logger.warn("Waiting ", this.backoffDuration, " many seconds before retrying...");
+                backoff();
                 logger.warn("Retrying the accept");
                 continue;
             }
@@ -85,6 +94,18 @@ public class StreamListener : Listener
             Stream clientStream = new SockStream(clientSocket);
             Connection clientConnection = Connection.newConnection(server, clientStream);
         }
+    }
+
+    private void backoff()
+    {
+        // Lock the mutex
+        this.backoffMutex.lock();
+
+        // Wait on the condition for `backoffDuration`-many duration
+        this.backoffCond.wait(this.backoffDuration);
+        
+        // Unlock the mutex
+        this.backoffMutex.unlock();
     }
 
     public override void startListener()
@@ -122,6 +143,25 @@ public class StreamListener : Listener
 
         /* Close the server socket, unblocking any `accept()` call */
         servSock.close();
+    }
+
+    /** 
+     * Wakes up the sleeping
+     * backoff sleeper which
+     * may have been activated
+     * in the case the `accept()`
+     * call was failing
+     */
+    public override void nudge()
+    {
+        // Lock the mutex
+        this.backoffMutex.lock();
+
+        // Wake up any sleeper (only one possible)
+        this.backoffCond.notify();
+
+        // Unlock the mutex
+        this.backoffMutex.unlock();
     }
 
     public static StreamListener create(Server server, Address bindAddress)


### PR DESCRIPTION
## Purpose :writing_hand: 

This is to handle the failing `accept()` calls which occur when too many file descriptors are present (too many files open) and we cannot create more (which `accept()` would do).

Therefore add a backoff mechanism, and retry accepting a little bit later. The logic is a user might have disconnected in that time. This also adds general handling such that we don't crash the `accept()` loop.

## Todo :white_check_mark: 

- [ ] Implementation
- [ ] Backoff
    - [x] Simple constant
    - [ ] Exponential with wakeup?

## Testing

- [ ] Test that it does what it should