### PR TITLE
Broken connection handling

### DIFF
--- a/source/renaissance/connection/connection.d
+++ b/source/renaissance/connection/connection.d
@@ -151,7 +151,9 @@ public class Connection : Thread
         logger.dbg("Shutting down river stream... [done]");
         
         // Clean up - notify disconnection
+        logger.dbg("Notifying the server of connection disconnect...");
         this.associatedServer.onConnectionDisconnect(this);
+        logger.dbg("Notifying the server of connection disconnect... [done]");
     }
 
     // FIXME: These should be part of the auth details

--- a/source/renaissance/connection/connection.d
+++ b/source/renaissance/connection/connection.d
@@ -144,6 +144,11 @@ public class Connection : Thread
         logger.dbg("Stopping tristanable manager...");
         this.tManager.stop();
         logger.dbg("Stopping tristanable manager... [done]");
+
+        // Clean up - shutdown the socket (close it)
+        logger.dbg("Shutting down river stream...");
+        clientStream.close();
+        logger.dbg("Shutting down river stream... [done]");
         
         // Clean up - notify disconnection
         this.associatedServer.onConnectionDisconnect(this);

--- a/source/renaissance/connection/connection.d
+++ b/source/renaissance/connection/connection.d
@@ -140,9 +140,11 @@ public class Connection : Thread
             }
         }
 
-        // Clean up (TODO: Shutdown the TManager)
+        // Clean up - shutdown the tristanable manager
+        logger.dbg("Stopping tristanable manager...");
+        this.tManager.stop();
+        logger.dbg("Stopping tristanable manager... [done]");
         
-
         // Clean up - notify disconnection
         this.associatedServer.onConnectionDisconnect(this);
     }

--- a/source/renaissance/connection/connection.d
+++ b/source/renaissance/connection/connection.d
@@ -96,9 +96,7 @@ public class Connection : Thread
 
         // TODO: Well, we'd tasky I guess so I'd need to use it there I guess
 
-        // TODO: Imp,ent nthe loop condition status (exit on error)
-        bool isGood = true;
-        queue_loop: while(isGood)
+        queue_loop: while(true)
         {
             // TODO: Addn a tasky/tristanable queue managing thing with
             // ... socket here (probably just the latter)

--- a/source/renaissance/connection/connection.d
+++ b/source/renaissance/connection/connection.d
@@ -98,7 +98,7 @@ public class Connection : Thread
 
         // TODO: Imp,ent nthe loop condition status (exit on error)
         bool isGood = true;
-        while(isGood)
+        queue_loop: while(isGood)
         {
             // TODO: Addn a tasky/tristanable queue managing thing with
             // ... socket here (probably just the latter)
@@ -113,9 +113,20 @@ public class Connection : Thread
             // ... (this would make sense as this woul dbe something)
             // ... we didn't test for
 
-            // Dequeue a message from the incoming queue
-            TaggedMessage incomingMessage = incomingQueue.dequeue();
-
+            
+            TaggedMessage incomingMessage;
+            
+            try
+            {
+                // Dequeue a message from the incoming queue
+                incomingMessage = incomingQueue.dequeue();
+            }
+            catch(TristanableException e)
+            {
+                logger.error("We had a fatal tristanable exception whilst dequeue()'ing: "~e.toString());
+                break queue_loop;
+            }
+            
             logger.dbg("Awoken? after dequeue()");
 
             // Process the message


### PR DESCRIPTION
## Purpose :writing_hand: 

We want to handle any errors that may occur with `Tristanable` when we are busy doing a `dequeue()`.

## Todo :white_check_mark: 

- [ ] Complete tristanable
    * There are some cases like network on remote end that I haven't considered, we should make tristanable throw an error on `dequeue()` if that happens
    * See https://github.com/deavmi/tristanable/pull/10
- [x] Shutdown tristanable when we exit the loop 
- [x] Shutdown the river stream
- [x] Notify server